### PR TITLE
Ingredients upgrades

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -13,20 +13,40 @@ using UnityEngine.UI;
 public class GameManager : MonoBehaviour
 {
     [SerializeField] Text counter;
+    [SerializeField] Text income;
     [SerializeField] GameObject cauldron;
+    [SerializeField] StoreUpgrade[] storeUpgrades;
+    [SerializeField] int updatesPerSecond = 5;
     bool isRotated = false;
-    int countValue = 0;
+    public float countValue = 0;
+    float nextTimeCheck = 1;
+    float incomePerSecond = 0;
+
     // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
-    {
-        displayNumber();
+    void Start() {
+        IncreaseAndDisplay();
     }
 
+    void Update(){
+        if (nextTimeCheck < Time.time) {
+            IdleIncome();
+            nextTimeCheck = Time.time + (1f/updatesPerSecond);
+        }
+    }
+
+    void IdleIncome(){
+        float income = 0;
+        foreach (var StoreUpgrade in storeUpgrades){
+           income += StoreUpgrade.IncomePerSecond(); 
+           StoreUpgrade.UpdateUI();
+        }
+        countValue += (income/updatesPerSecond);
+        incomePerSecond = income;
+    }
 
     // Funciton that is called on click of the cauldron, increases the counter and executes the animation
-    public void increaseAndDisplay()
-    {
-        increase();
+    public void IncreaseAndDisplay() {
+        Increase();
 
         //initial pop of cauldron
         cauldron.transform.DOBlendableScaleBy(new Vector3(0.05f, 0.05f, 0.05f), 0.05f).OnComplete(CauldronScaleBack);
@@ -35,14 +55,24 @@ public class GameManager : MonoBehaviour
         displayNumber();
     }
 
+    //Function that verifies if you can pay the upgrade
+    public bool PurchaseUpgrade(int cost) {
+        if (countValue >= cost) {
+            countValue -= cost;
+            displayNumber();
+            return true;
+        }
+        return false;
+    }
+
     //Function that pops back the cauldron
-    void CauldronScaleBack(){
+    void CauldronScaleBack() {
         cauldron.transform.DOBlendableScaleBy(new Vector3(-0.05f, -0.05f, -0.05f), 0.05f);
     }
 
     //Rotates the cauldron and back every other click, allowing a back and forth motion
     //Might eventually change it to do a rotation/position at random
-    void RotateCauldron(){
+    void RotateCauldron() {
         if (isRotated){
             cauldron.transform.DORotate(new Vector3(0, 0, -7), 0.01f);
             isRotated = false;
@@ -52,21 +82,14 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-
-    }
-
     //increases count value, called in the increaseAndDisplay() function
-    void increase()
-    {
+    void Increase() {
         countValue++;
     }
 
     //Changes the value of the counter in the UI. Called in Start() and increaseAndDisplay()
-    void displayNumber()
-    {
-        counter.text = countValue.ToString();
+    void displayNumber() {
+        counter.text = Mathf.RoundToInt(countValue).ToString();
+        income.text = incomePerSecond.ToString() + "/s";
     }
 }

--- a/Assets/Scripts/StoreUpgrade.cs
+++ b/Assets/Scripts/StoreUpgrade.cs
@@ -7,10 +7,19 @@ public class StoreUpgrade : MonoBehaviour
     //Fields to link through Unity interface to be able to update the text on the upgrade buttons
     [SerializeField] Text priceValue;
     [SerializeField] Text income;
+    [SerializeField] Button upgradeButton;
+    [SerializedField] Image ingredientImage;
+    [SerializeField] Text ingredientName;
+
 
     // Variables to change in the unity window to be able to reuse the script no matter the cost/effect of the upgrade
     public int startPrice = 20;
     public float numPerUpgrade = 0.1f;
+    public string ingredient;
+
+    //Game manager object to have access to "GameManager.cs" functions
+    public GameManager gameManager;
+
 
     //Set price multiplier for all the upgrades of the game. Changing it will change the price curve & pace of the game
     float priceMultiplier = 1.1f;
@@ -26,14 +35,26 @@ public class StoreUpgrade : MonoBehaviour
 
     //
     public void BuyUpgrade(){
-        
+        int price = CalculatePrice();
+        bool purchasePossible = gameManager.PurchaseUpgrade(price);
+        if (purchasePossible){
+            level++;
+            UpdateUI();
+        }
     }
 
     //  Updates both price and effect of the upgrade on the upgrade button
-    void UpdateUI()
+    public void UpdateUI()
     {
         priceValue.text = CalculatePrice().ToString();
         income.text = level.ToString() + " x " + numPerUpgrade + "/s";
+        bool canBuy = gameManager.countValue >= CalculatePrice();
+        upgradeButton.interactable = canBuy;
+
+        bool isPurchased = level <= 1 && gameManager.countValue >= CalculatePrice();
+        ingredientImage.color = isPurchased ? Color.white : Color.black;
+
+        ingredientName.text = isPurchased ? ingredient : "???";
     }
 
     //Function that does the math for calculating the upgrade price


### PR DESCRIPTION
- Ingredients should now be purchasable
- Ingredients should now affect the count of the items per second & refresh the item counter 5 times per second
- picture and name of the ingredient will be unavailable until you can purchase it for the first time

IMPORTANT: the features have NOT been tested or linked yet because i don't wanna fuck with the UI when Nisma is still working on it. It is fully possible that they don't work